### PR TITLE
File Feed private API support added

### DIFF
--- a/govt.go
+++ b/govt.go
@@ -1,5 +1,5 @@
 /*
-govt is a VirusTotal API v2 client written for the Go programming language.
+Package govt is a VirusTotal API v2 client written for the Go programming language.
 
 Written by Willi Ballenthin while at Mandiant.
 June, 2013.
@@ -13,7 +13,10 @@ October, 2014.
 package govt
 
 import (
+	"archive/tar"
+	"bufio"
 	"bytes"
+	"compress/bzip2"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,7 +43,7 @@ type Status struct {
 	VerboseMsg   string `json:"verbose_msg"`
 }
 
-// FileResult
+// FileDownloadResult
 type FileDownloadResult struct {
 	Content []byte
 }
@@ -54,6 +57,7 @@ type FileScan struct {
 }
 
 type FileReportDistrib struct {
+	Status
 	Md5           string `json:"md5"`
 	Sha1          string `json:"sha1"`
 	Sha256        string `json:"sha256"`
@@ -69,6 +73,34 @@ type FileReportDistrib struct {
 	VHash         string `json:"vhash"`
 	// Ugh. VT inconsistency. Data is an array rather than k/v like other APIs
 	Scans map[string][]string `json:"report"`
+}
+
+// FileFeed high level elements of the file feed API
+// As much more data but kept simple for brevity
+type FileFeed struct {
+	Vhash               string        `json:"vhash"`
+	SubmissionNames     []string      `json:"submission_names"`
+	ScanDate            string        `json:"scan_date"`
+	FirstSeen           string        `json:"first_seen"`
+	TimesSubmitted      int           `json:"times_submitted"`
+	Size                int           `json:"size"`
+	ScanID              string        `json:"scan_id"`
+	Total               int           `json:"total"`
+	HarmlessVotes       int           `json:"harmless_votes"`
+	VerboseMsg          string        `json:"verbose_msg"`
+	Sha256              string        `json:"sha256"`
+	Type                string        `json:"type"`
+	Link                string        `json:"link"`
+	Positives           int           `json:"positives"`
+	Ssdeep              string        `json:"ssdeep"`
+	Md5                 string        `json:"md5"`
+	Permalink           string        `json:"permalink"`
+	Sha1                string        `json:"sha1"`
+	ResponseCode        int           `json:"response_code"`
+	CommunityReputation int           `json:"community_reputation"`
+	MaliciousVotes      int           `json:"malicious_votes"`
+	ITWUrls             []interface{} `json:"ITW_urls"`
+	LastSeen            string        `json:"last_seen"`
 }
 
 type FileDistributionResults []FileReportDistrib
@@ -268,20 +300,20 @@ type ClientError struct {
 }
 
 // Error returns a string representation of the error condition.
-func (self ClientError) Error() string {
-	return self.msg
+func (client ClientError) Error() string {
+	return client.msg
 }
 
 // UseDefaultUrl configures a `Client` to use the default public
 //   VT URL published on their website.
-func (self *Client) UseDefaultUrl() {
-	self.Url = "https://www.virustotal.com/vtapi/v2/"
+func (client *Client) UseDefaultUrl() {
+	client.Url = "https://www.virustotal.com/vtapi/v2/"
 }
 
 // checkApiKey ensures that the user configured her API key,
 //   or returns an error.
-func (self *Client) checkApiKey() (err error) {
-	if self.Apikey == "" {
+func (client *Client) checkApiKey() (err error) {
+	if client.Apikey == "" {
 		return ClientError{msg: "Empty API key is invalid"}
 	} else {
 		return nil
@@ -292,13 +324,13 @@ func (self *Client) checkApiKey() (err error) {
 //  returns the response if the status code is HTTP 200
 // `parameters` should not include the apikey.
 // The caller must call `resp.Body.Close()`.
-func (self *Client) makeApiGetRequest(fullurl string, parameters map[string]string) (resp *http.Response, err error) {
-	if err = self.checkApiKey(); err != nil {
+func (client *Client) makeApiGetRequest(fullurl string, parameters map[string]string) (resp *http.Response, err error) {
+	if err = client.checkApiKey(); err != nil {
 		return resp, err
 	}
 
 	values := url.Values{}
-	values.Set("apikey", self.Apikey)
+	values.Set("apikey", client.Apikey)
 	for k, v := range parameters {
 		values.Add(k, v)
 	}
@@ -310,8 +342,8 @@ func (self *Client) makeApiGetRequest(fullurl string, parameters map[string]stri
 		return resp, err
 	}
 
-	if self.BasicAuthUsername != "" {
-		req.SetBasicAuth(self.BasicAuthUsername, self.BasicAuthPassword)
+	if client.BasicAuthUsername != "" {
+		req.SetBasicAuth(client.BasicAuthUsername, client.BasicAuthPassword)
 	}
 
 	resp, err = httpClient.Do(req)
@@ -320,7 +352,7 @@ func (self *Client) makeApiGetRequest(fullurl string, parameters map[string]stri
 	}
 
 	if resp.StatusCode != 200 {
-		var msg string = fmt.Sprintf("Unexpected status code: %d", resp.StatusCode)
+		var msg = fmt.Sprintf("Unexpected status code: %d", resp.StatusCode)
 		resp.Write(os.Stdout)
 		return resp, ClientError{msg: msg}
 	}
@@ -332,13 +364,13 @@ func (self *Client) makeApiGetRequest(fullurl string, parameters map[string]stri
 //  returns the response if the status code is HTTP 200
 // `parameters` should not include the apikey.
 // The caller must call `resp.Body.Close()`.
-func (self *Client) makeApiPostRequest(fullurl string, parameters map[string]string) (resp *http.Response, err error) {
-	if err = self.checkApiKey(); err != nil {
+func (client *Client) makeApiPostRequest(fullurl string, parameters map[string]string) (resp *http.Response, err error) {
+	if err = client.checkApiKey(); err != nil {
 		return resp, err
 	}
 
 	values := url.Values{}
-	values.Set("apikey", self.Apikey)
+	values.Set("apikey", client.Apikey)
 	for k, v := range parameters {
 		values.Add(k, v)
 	}
@@ -349,7 +381,7 @@ func (self *Client) makeApiPostRequest(fullurl string, parameters map[string]str
 	}
 
 	if resp.StatusCode != 200 {
-		var msg string = fmt.Sprintf("Unexpected status code: %d", resp.StatusCode)
+		var msg = fmt.Sprintf("Unexpected status code: %d", resp.StatusCode)
 		resp.Write(os.Stdout)
 		return resp, ClientError{msg: msg}
 	}
@@ -361,7 +393,7 @@ func (self *Client) makeApiPostRequest(fullurl string, parameters map[string]str
 //  returns the response if the status code is HTTP 200
 // `parameters` should not include the apikey.
 // The caller must call `resp.Body.Close()`.
-func (self *Client) makeApiUploadRequest(fullurl string, parameters map[string]string, paramName, path string) (resp *http.Response, err error) {
+func (client *Client) makeApiUploadRequest(fullurl string, parameters map[string]string, paramName, path string) (resp *http.Response, err error) {
 	// open the file
 	file, err := os.Open(path)
 	if err != nil {
@@ -384,7 +416,7 @@ func (self *Client) makeApiUploadRequest(fullurl string, parameters map[string]s
 	// copy our file into the file part of our multipart/mime message
 	_, err = io.Copy(part, file)
 	// set Apikey as parameter
-	parameters["apikey"] = self.Apikey
+	parameters["apikey"] = client.Apikey
 	// write parameters into the request
 	for key, val := range parameters {
 		_ = writer.WriteField(key, val)
@@ -403,15 +435,15 @@ func (self *Client) makeApiUploadRequest(fullurl string, parameters map[string]s
 	//  this could also be a bug in go actually.
 	postReq.Header.Add("Content-Type", fdct)
 	// prepare http client
-	client := &http.Client{}
+	httpClient := &http.Client{}
 	// send our request off, get response and/or error
-	resp, err = client.Do(postReq)
+	resp, err = httpClient.Do(postReq)
 	if err != nil {
 		return resp, err
 	}
 	// oops something went wrong
 	if resp.StatusCode != 200 {
-		var msg string = fmt.Sprintf("Unexpected status code: %d", resp.StatusCode)
+		var msg = fmt.Sprintf("Unexpected status code: %d", resp.StatusCode)
 		resp.Write(os.Stdout)
 		return resp, ClientError{msg: msg}
 	}
@@ -419,6 +451,7 @@ func (self *Client) makeApiUploadRequest(fullurl string, parameters map[string]s
 	return resp, nil
 }
 
+// Parameters for the HTTP requests
 type Parameters map[string]string
 
 // fetchApiJson makes a request to the API and decodes the response.
@@ -426,19 +459,19 @@ type Parameters map[string]string
 // `actionurl` is the final path component that specifies the API call
 // `parameters` does not include the API key
 // `result` is modified as an output parameter. It must be a pointer to a VT JSON structure.
-func (self *Client) fetchApiJson(method string, actionurl string, parameters Parameters, result interface{}) (err error) {
-	theurl := self.Url + actionurl
+func (client *Client) fetchApiJson(method string, actionurl string, parameters Parameters, result interface{}) (err error) {
+	theurl := client.Url + actionurl
 	var resp *http.Response
 	switch method {
 	case "GET":
-		resp, err = self.makeApiGetRequest(theurl, parameters)
+		resp, err = client.makeApiGetRequest(theurl, parameters)
 	case "POST":
-		resp, err = self.makeApiPostRequest(theurl, parameters)
+		resp, err = client.makeApiPostRequest(theurl, parameters)
 	case "FILE":
 		// get the path to our file from parameters["filename"]
 		path := parameters["filename"]
 		// call makeApiUploadRequest with fresh/empty Parameters
-		resp, err = self.makeApiUploadRequest(theurl, Parameters{}, "file", path)
+		resp, err = client.makeApiUploadRequest(theurl, Parameters{}, "file", path)
 	}
 	if err != nil {
 		return err
@@ -454,10 +487,10 @@ func (self *Client) fetchApiJson(method string, actionurl string, parameters Par
 }
 
 // fetchApiFile makes a get request to the API and returns the file content
-func (self *Client) fetchApiFile(actionurl string, parameters Parameters) (data []byte, err error) {
-	theurl := self.Url + actionurl
+func (client *Client) fetchApiFile(actionurl string, parameters Parameters) (data []byte, err error) {
+	theurl := client.Url + actionurl
 	var resp *http.Response
-	resp, err = self.makeApiGetRequest(theurl, parameters)
+	resp, err = client.makeApiGetRequest(theurl, parameters)
 	if err != nil {
 		return nil, err
 	}
@@ -470,22 +503,22 @@ func (self *Client) fetchApiFile(actionurl string, parameters Parameters) (data 
 }
 
 // ScanUrl asks VT to redo analysis on the specified file.
-func (self *Client) ScanUrl(url string) (r *ScanUrlResult, err error) {
+func (client *Client) ScanUrl(url string) (r *ScanUrlResult, err error) {
 	r = &ScanUrlResult{}
-	err = self.fetchApiJson("POST", "url/scan", Parameters{"url": url}, r)
+	err = client.fetchApiJson("POST", "url/scan", Parameters{"url": url}, r)
 	return r, err
 }
 
 // ScanUrls asks VT to redo analysis on the specified files.
-func (self *Client) ScanUrls(urls []string) (r *ScanUrlResults, err error) {
+func (client *Client) ScanUrls(urls []string) (r *ScanUrlResults, err error) {
 	r = &ScanUrlResults{}
 	parameters := Parameters{"resource": strings.Join(urls, "\n")}
-	err = self.fetchApiJson("POST", "url/scan", parameters, r)
+	err = client.fetchApiJson("POST", "url/scan", parameters, r)
 	return r, err
 }
 
 // ScanFile asks VT to analysis on the specified file, thats also uploaded.
-func (self *Client) ScanFile(file string) (r *ScanFileResult, err error) {
+func (client *Client) ScanFile(file string) (r *ScanFileResult, err error) {
 	r = &ScanFileResult{}
 	// HACK: here i misuse fetchApiJson a bit,
 	//  introduced a new "method" called 'File',
@@ -494,115 +527,164 @@ func (self *Client) ScanFile(file string) (r *ScanFileResult, err error) {
 	//
 	//  i use Parameters map to pass the filename to fetchApiJson, which
 	//  in turn drops the map and calls makeApiUploadRequest with a fresh one
-	err = self.fetchApiJson("FILE", "file/scan", Parameters{"filename": file}, r)
+	err = client.fetchApiJson("FILE", "file/scan", Parameters{"filename": file}, r)
 	return r, err
 }
 
 // RescanFile asks VT to redo analysis on the specified file.
-func (self *Client) RescanFile(md5 string) (r *RescanFileResult, err error) {
+func (client *Client) RescanFile(md5 string) (r *RescanFileResult, err error) {
 	r = &RescanFileResult{}
-	err = self.fetchApiJson("POST", "file/rescan", Parameters{"resource": md5}, r)
+	err = client.fetchApiJson("POST", "file/rescan", Parameters{"resource": md5}, r)
 	return r, err
 }
 
 // RescanFiles asks VT to redo analysis on the specified files.
-func (self *Client) RescanFiles(md5s []string) (r *RescanFileResults, err error) {
+func (client *Client) RescanFiles(md5s []string) (r *RescanFileResults, err error) {
 	r = &RescanFileResults{}
 	parameters := Parameters{"resource": strings.Join(md5s, ",")}
-	err = self.fetchApiJson("POST", "file/rescan", parameters, r)
+	err = client.fetchApiJson("POST", "file/rescan", parameters, r)
 	return r, err
 }
 
-// GetFileDetailedReport fetches the AV scan reports tracked by VT given an MD5 hash value.
+// GetDetailedFileReport fetches the AV scan reports tracked by VT given an MD5 hash value.
 // This API is part of the VTI Private API, requiring a licenced API key
-func (self *Client) GetDetailedFileReport(md5 string) (r *DetailedFileReport, err error) {
+func (client *Client) GetDetailedFileReport(md5 string) (r *DetailedFileReport, err error) {
 	r = &DetailedFileReport{}
-	err = self.fetchApiJson("GET", "file/report", Parameters{"resource": md5, "allinfo": "1"}, r)
+	err = client.fetchApiJson("GET", "file/report", Parameters{"resource": md5, "allinfo": "1"}, r)
 	return r, err
 }
 
 // GetFileReport fetches the AV scan reports tracked by VT given an MD5 hash value.
-func (self *Client) GetFileReport(md5 string) (r *FileReport, err error) {
+func (client *Client) GetFileReport(md5 string) (r *FileReport, err error) {
 	r = &FileReport{}
-	err = self.fetchApiJson("GET", "file/report", Parameters{"resource": md5}, r)
+	err = client.fetchApiJson("GET", "file/report", Parameters{"resource": md5}, r)
 	return r, err
 }
 
 // GetFileReports fetches the AV scan reports tracked by VT given set of MD5 hash values.
-func (self *Client) GetFileReports(md5s []string) (r *FileReportResults, err error) {
+func (client *Client) GetFileReports(md5s []string) (r *FileReportResults, err error) {
 	r = &FileReportResults{}
 	parameters := Parameters{"resource": strings.Join(md5s, ",")}
-	err = self.fetchApiJson("GET", "file/report", parameters, r)
+	err = client.fetchApiJson("GET", "file/report", parameters, r)
 	return r, err
 }
 
 // GetFile fetches a file from VT that matches a given md5/sha1/sha256 sum
-func (self *Client) GetFile(hash string) (r *FileDownloadResult, err error) {
+func (client *Client) GetFile(hash string) (r *FileDownloadResult, err error) {
 	r = &FileDownloadResult{}
 	parameters := Parameters{"hash": hash}
-	data, err := self.fetchApiFile("file/download", parameters)
+	data, err := client.fetchApiFile("file/download", parameters)
 	r.Content = data
 	return r, err
 }
 
-func (self *Client) GetFileNetworkTraffic(hash string) (r *FileDownloadResult, err error) {
+func (client *Client) GetFileNetworkTraffic(hash string) (r *FileDownloadResult, err error) {
 	r = &FileDownloadResult{}
 	parameters := Parameters{"hash": hash}
-	data, err := self.fetchApiFile("file/network-traffic", parameters)
+	data, err := client.fetchApiFile("file/network-traffic", parameters)
 	r.Content = data
 	return r, err
 }
 
 // GetFileDistribution fetches files from the VT distribution API
-func (self *Client) GetFileDistribution(params *Parameters) (r *FileDistributionResults, err error) {
+func (client *Client) GetFileDistribution(params *Parameters) (r *FileDistributionResults, err error) {
 	r = &FileDistributionResults{}
-	err = self.fetchApiJson("GET", "file/distribution", *params, r)
+	err = client.fetchApiJson("GET", "file/distribution", *params, r)
 	return r, err
+}
+
+func readData(br *bufio.Reader) (line []byte, err error) {
+	isPrefix := true
+	buff := []byte{}
+	for isPrefix {
+		buff, isPrefix, err = br.ReadLine()
+		line = append(line, buff...)
+	}
+	return line, err
+}
+
+// GetFileFeed fetches files from the VT feed API
+func (client *Client) GetFileFeed(packageRange string) ([]FileFeed, error) {
+	var resp *http.Response
+	feedElements := []FileFeed{}
+	resp, err := client.makeApiGetRequest(client.Url+"file/feed", Parameters{"package": packageRange})
+	if err != nil {
+		return feedElements, err
+	}
+	defer resp.Body.Close()
+
+	// We get a tar.bzip2 from the API
+	br := bzip2.NewReader(resp.Body)
+	tr := tar.NewReader(br)
+
+	// Iterate through the files in the archive.
+	for {
+		_, iterErr := tr.Next()
+		if iterErr == io.EOF {
+			// end of tar archive
+			break
+		}
+		br := bufio.NewReader(tr)
+
+		// File contains one JSON obj per line
+		line, readErr := readData(br)
+		for readErr == nil {
+			result := FileFeed{}
+			dec := json.NewDecoder(bytes.NewReader(line))
+			if decodeErr := dec.Decode(&result); decodeErr != nil {
+				return feedElements, decodeErr
+			}
+			feedElements = append(feedElements, result)
+			// Get next line in the file
+			line, readErr = readData(br)
+		}
+	}
+	return feedElements, err
 }
 
 // GetUrlReport fetches the AV scan reports tracked by VT given a URL.
 // Does not support the optional `scan` parameter.
-func (self *Client) GetUrlReport(url string) (r *UrlReport, err error) {
+func (client *Client) GetUrlReport(url string) (r *UrlReport, err error) {
 	r = &UrlReport{}
-	err = self.fetchApiJson("POST", "url/report", Parameters{"resource": url}, r)
+	err = client.fetchApiJson("POST", "url/report", Parameters{"resource": url}, r)
 	return r, err
 }
 
 // GetUrlReports fetches AV scan reports tracked by VT given URLs.
 // Does not support the optional `scan` parameter.
-func (self *Client) GetUrlReports(urls []string) (r *UrlReports, err error) {
+func (client *Client) GetUrlReports(urls []string) (r *UrlReports, err error) {
 	r = &UrlReports{}
 	parameters := Parameters{"resource": strings.Join(urls, "\n")}
-	err = self.fetchApiJson("POST", "url/report", parameters, r)
+	err = client.fetchApiJson("POST", "url/report", parameters, r)
 	return r, err
 }
 
 // GetIpReport fetches the passive DNS information about an IP address.
-func (self *Client) GetIpReport(ip string) (r *IpReport, err error) {
+func (client *Client) GetIpReport(ip string) (r *IpReport, err error) {
 	r = &IpReport{}
-	err = self.fetchApiJson("GET", "ip-address/report", Parameters{"ip": ip}, r)
+	err = client.fetchApiJson("GET", "ip-address/report", Parameters{"ip": ip}, r)
 	return r, err
 }
 
 // GetDomainReport fetches the passive DNS information about a DNS address.
-func (self *Client) GetDomainReport(domain string) (r *DomainReport, err error) {
+func (client *Client) GetDomainReport(domain string) (r *DomainReport, err error) {
 	r = &DomainReport{}
-	err = self.fetchApiJson("GET", "domain/report", Parameters{"domain": domain}, r)
+	err = client.fetchApiJson("GET", "domain/report", Parameters{"domain": domain}, r)
 	return r, err
 }
 
 // MakeComment adds a comment to a file/URL/IP/domain.
-func (self *Client) MakeComment(resource string, comment string) (r *Status, err error) {
+func (client *Client) MakeComment(resource string, comment string) (r *Status, err error) {
 	r = &Status{}
 	parameters := Parameters{"resource": resource, "comment": comment}
-	err = self.fetchApiJson("POST", "comments/put", parameters, r)
+	err = client.fetchApiJson("POST", "comments/put", parameters, r)
 	return r, err
 }
 
 // GetComments gets comments for file/URL/IP/domain.
-func (self *Client) GetComments(resource string) (r *CommentReport, err error) {
+func (client *Client) GetComments(resource string) (r *CommentReport, err error) {
 	r = &CommentReport{}
 	parameters := Parameters{"resource": resource}
-	err = self.fetchApiJson("GET", "comments/get", parameters, r)
+	err = client.fetchApiJson("GET", "comments/get", parameters, r)
 	return r, err
 }


### PR DESCRIPTION
Added support for the File Feed API endpoint. Documentation can be found here: https://www.virustotal.com/en/documentation/private-api/#file-feed
I also added three parameters to `go test`:
* `-apikey` for the API key, no need to hard-code it
* `-run-expensive` for more than the four basic tests
* `-run-private for` tests requiring access to the private API

The `FileFeed` struct is very high level, I omitted a couple of elements for brevity.
Did some minor cleanup and fixed some tests.