### PR TITLE
exporting MakeAPIGetRequest

### DIFF
--- a/govt.go
+++ b/govt.go
@@ -320,11 +320,11 @@ func (client *Client) checkApiKey() (err error) {
 	}
 }
 
-// makeApiGetRequest fetches a URL with querystring via HTTP GET and
+// MakeAPIGetRequest fetches a URL with querystring via HTTP GET and
 //  returns the response if the status code is HTTP 200
 // `parameters` should not include the apikey.
 // The caller must call `resp.Body.Close()`.
-func (client *Client) makeApiGetRequest(fullurl string, parameters map[string]string) (resp *http.Response, err error) {
+func (client *Client) MakeAPIGetRequest(fullurl string, parameters map[string]string) (resp *http.Response, err error) {
 	if err = client.checkApiKey(); err != nil {
 		return resp, err
 	}
@@ -464,7 +464,7 @@ func (client *Client) fetchApiJson(method string, actionurl string, parameters P
 	var resp *http.Response
 	switch method {
 	case "GET":
-		resp, err = client.makeApiGetRequest(theurl, parameters)
+		resp, err = client.MakeAPIGetRequest(theurl, parameters)
 	case "POST":
 		resp, err = client.makeApiPostRequest(theurl, parameters)
 	case "FILE":
@@ -490,7 +490,7 @@ func (client *Client) fetchApiJson(method string, actionurl string, parameters P
 func (client *Client) fetchApiFile(actionurl string, parameters Parameters) (data []byte, err error) {
 	theurl := client.Url + actionurl
 	var resp *http.Response
-	resp, err = client.makeApiGetRequest(theurl, parameters)
+	resp, err = client.MakeAPIGetRequest(theurl, parameters)
 	if err != nil {
 		return nil, err
 	}
@@ -607,7 +607,7 @@ func readData(br *bufio.Reader) (line []byte, err error) {
 func (client *Client) GetFileFeed(packageRange string) ([]FileFeed, error) {
 	var resp *http.Response
 	feedElements := []FileFeed{}
-	resp, err := client.makeApiGetRequest(client.Url+"file/feed", Parameters{"package": packageRange})
+	resp, err := client.MakeAPIGetRequest(client.Url+"file/feed", Parameters{"package": packageRange})
 	if err != nil {
 		return feedElements, err
 	}


### PR DESCRIPTION
I had a use case where I wanted to fetch a file but instead of writing it to disk/memory I wanted to use the body reader as payload for anther request. So GET sample -> POST sample
I think this is a common use case where you have a sample downloader that pushes the samples to a remote destination.